### PR TITLE
Turn off Cypress recording

### DIFF
--- a/.github/workflows/Build and test.yml
+++ b/.github/workflows/Build and test.yml
@@ -20,7 +20,8 @@ jobs:
         with:
           #start: yarn dev
           start: yarn start
-          record: true
+          record: false
         env:         
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY}} # key od project created in cypress.io
+          # build launched by dependabot does not have access to secrets
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY}} # key of project created in cypress.io
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided


### PR DESCRIPTION
Turn off Cypress dashboard recording because:
- With the free account I reach the limit in just some deploy
- Dependabot build cannot access to secret keys so it is passing empty and it fails the build creating confusion