### PR TITLE
show user and application locale

### DIFF
--- a/CSS/page.module.sass
+++ b/CSS/page.module.sass
@@ -1,5 +1,5 @@
 @use "./colors.module.sass"
-@use "./typography.sass" as text
+@use "./typography.module.sass" as text
 
 .container
   padding: 1rem  

--- a/CSS/styles.module.sass
+++ b/CSS/styles.module.sass
@@ -2,8 +2,9 @@
 
 //@import "./colors.sass"  // this is still applied and visible because import makes it global visible
 @use "./colors.module.sass" as colors
-@import "./typography.sass"
+@use "./typography.module.sass" as text
 @import "./card.sass"
+@import "./typography.sass"
 
 @mixin button-padding()
   padding: 2px 6px
@@ -72,13 +73,6 @@
   background-color: colors.$background
   box-shadow: 0 0.25rem 0.5rem colors.$background-shadow
     
-
-.fieldLabel
-  color: $primary
-
-.fieldValue
-  color: $secondary
-  font-weight: bold    
 
 @mixin notificationBar()
   position: fixed

--- a/CSS/typography.module.sass
+++ b/CSS/typography.module.sass
@@ -1,0 +1,14 @@
+// this one is no more visible
+//.text_small 
+//  font-size: 80%
+
+// this one can be used as: @include text.small
+@mixin small
+  font-size: 80%
+
+@mixin code()
+  padding: .25em
+  line-height: 0
+
+//small
+//  font-size: 80%

--- a/CSS/typography.module.sass
+++ b/CSS/typography.module.sass
@@ -1,7 +1,3 @@
-// this one is no more visible
-//.text_small 
-//  font-size: 80%
-
 // this one can be used as: @include text.small
 @mixin small
   font-size: 80%
@@ -9,6 +5,4 @@
 @mixin code()
   padding: .25em
   line-height: 0
-
-//small
-//  font-size: 80%
+  font-family: monospace

--- a/CSS/typography.sass
+++ b/CSS/typography.sass
@@ -1,5 +1,18 @@
-.text_small 
-  font-size: 80%
+@use "typography.module.sass" as text
+@use "colors.module.sass"
+  
+.text_small
+  @inlude text.small
 
-@mixin small()
-  font-size: 80%
+//code
+//  @inlude text.code()
+
+.fieldLabel
+  @include text.small
+  color: colors.$secondary
+  white-space: nowrap
+  
+
+.fieldValue
+  color: colors.$primary
+  font-weight: bold    

--- a/CSS/typography.sass
+++ b/CSS/typography.sass
@@ -4,14 +4,10 @@
 .text_small
   @inlude text.small
 
-//code
-//  @inlude text.code()
-
 .fieldLabel
   @include text.small
   color: colors.$secondary
-  white-space: nowrap
-  
+  white-space: nowrap  
 
 .fieldValue
   color: colors.$primary

--- a/common/hooks.ts
+++ b/common/hooks.ts
@@ -17,19 +17,23 @@ export const useMountEffect = (handler:EffectCallback) => useEffect(handler, [])
  * @method locale: get the locale from browser. Default is "it".
  */
  export const useLocale = () => {
-
+  const [browserLocale, setBrowserLocale] = useState<string|undefined>(undefined)
   const [locale, setLocale] = useState(defaultLocale)
   const [language, setLanguage] = useState("it") 
 
   useEffect(() => {
-    console.log("useLocale::window.navigator.language", window.navigator.language)
-    const locale = getLocale(window.navigator.language) || defaultLocale
+    // DON'T use window.navigator.language outside useEffect (window is not defined)
+    //console.log("useLocale::window.navigator.language", window.navigator.language)
+    const browserLanguage = window.navigator.language
+    setBrowserLocale(browserLanguage)
+    const locale = getLocale(browserLanguage) || defaultLocale
     const language = locale.substring(0, 2)
     setLocale(locale)
     setLanguage(language)
   }, [])
   
   return {
+    browserLocale: browserLocale,
     locale: locale,
     language: language,
     setLocale,

--- a/components/Field.tsx
+++ b/components/Field.tsx
@@ -1,0 +1,23 @@
+import { FC } from "react"
+import styles from "../CSS/styles.module.sass"
+import FieldValue from "./FieldValue"
+import FieldLabel from "./FieldLabel"
+
+interface Props {
+  label:string
+  value:string|undefined
+  inline?:boolean
+  singleRow?:boolean
+}
+
+const Field:FC<Props> = props => {
+  const {label, value, inline, singleRow} = props
+  const style = {display: inline ? "inline" : "block" }
+
+  return <div style={style}>
+    <FieldLabel text={label} inline={singleRow}  />
+    <FieldValue value={value} inline={singleRow}  />
+  </div>
+}
+
+export default Field

--- a/components/FieldLabel.tsx
+++ b/components/FieldLabel.tsx
@@ -1,0 +1,11 @@
+import { FC } from "react"
+import styles from "../CSS/styles.module.sass"
+
+const FieldLabel:FC<{text:string, inline?:boolean}> = props => {
+  const {text, inline} = props
+  const style = {display: inline ? "inline" : "block" }
+
+  return <div style={style} className={styles.fieldLabel}>{text}</div>
+}
+
+export default FieldLabel

--- a/components/FieldValue.tsx
+++ b/components/FieldValue.tsx
@@ -1,0 +1,11 @@
+import { FC } from "react"
+import styles from "../CSS/styles.module.sass"
+
+const FieldLabel:FC<{value:string|undefined, inline?:boolean}> = props => {
+  const {value, inline} = props
+  const style = {display: inline ? "inline" : "block" }
+
+  return <div style={style} className={styles.fieldValue}>{value}</div>
+}
+
+export default FieldLabel

--- a/components/styles.ts
+++ b/components/styles.ts
@@ -3,9 +3,10 @@ export type ButtonColor = "primary" | "secondary" | "alternative"
 export type ButtonStyle = "border" | "text"
 export type ButtonVariant = "primary" | "alternative"
 
-
+/*
 const primaryColor = "#074A6A"
 const secondaryColor = "#04273B"
 const alternativeColor = "#FF4141"
 const lightColor = "#F9F9F9"
 const darkColor = "#333333"
+*/

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from "react"
-import { DefaultPage } from "../components/DefaultPage"
 import { NextPageContext } from "next"
+import { DefaultPage } from "../components/DefaultPage"
 import styles from "../CSS/styles.module.sass"
-import { Table } from "react-bootstrap"
+import { Col, Container, Row, Table } from "react-bootstrap"
+import { useLocale } from "../common/hooks"
+import Field from "../components/Field"
 
 export default function Page(props:NextPageContext) {
   const [error, setError] = useState<string>()
+  const [browserLanguage] = useState<string>("unknown")
+  const locale = useLocale()
 
   const reload = async () => {
 
@@ -13,19 +17,28 @@ export default function Page(props:NextPageContext) {
 
   useEffect(() => {
     reload()
+    
+    //localStorage.setItem("language", browserLanguage)
   }, [])
 
   return <DefaultPage
     title="Settings" 
     description="Settings of the application and of the user browser">  
 
-    <p>
-    There is no content yet.
-    </p>
-
-    <Table>
-
-    </Table>
+<div className="section">
+    <Container >
+      <Row>
+        <Col>
+          <Field label="Browser language" value={locale.browserLocale} />
+        </Col>
+        <Col>
+          <Field label="Application language" value={locale.language} />
+        </Col>
+        <Col>
+          <Field label="Application locale" value={locale.locale} />
+        </Col>
+      </Row>
+    </Container></div>
     
   </DefaultPage>  
 }


### PR DESCRIPTION
# Why we need these changes
As part of #76 we need to show the user locale and the application locale.  

## What is changed
- shows browser and application locale in settings page
- added Field, FieldLabel and FieldValue components

### Screenshots

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/876490/161381112-4650281c-eec8-40bc-8c31-326881f7a955.png)

</details>

## How is it tested

Local test.

## Actions

If the build is labeled ``build:success`` it is possible to run the following actions adding the relative label:  

- ``docker:image``: Build a Docker image and publish it
